### PR TITLE
Fix problems with follow sets, epsilon, and the LR0 action table.

### DIFF
--- a/src/lr0/LR0Parser.java
+++ b/src/lr0/LR0Parser.java
@@ -141,7 +141,7 @@ public class LR0Parser extends LRParser {
         for (int i = 0; i < canonicalCollection.size(); i++) {
             for (LR0Item item : canonicalCollection.get(i).getItems()) {
                 if (item.getDotPointer() == item.getRightSide().length) {
-                    if (item.getLeftSide().equals("s'")) {
+                    if (item.getLeftSide().equals("S'")) {
                         actionTable[i].put("$", new Action(ActionType.ACCEPT, 0));
                     } else {
                         HashSet<String> terminals = grammar.getTerminals();

--- a/src/lr1/LR1State.java
+++ b/src/lr1/LR1State.java
@@ -38,7 +38,12 @@ public class LR1State {
                     }
                     HashSet<Rule> rules = grammar.getRuledByLeftVariable(item.getCurrent());
                     for(Rule rule : rules){
-                        temp.add(new LR1Item(rule.getLeftSide(),rule.getRightSide(),0,lookahead));
+                        String[] rhs = rule.getRightSide();
+                        int finished = 0;
+                        if (rhs.length == 1 && rhs[0].equals("epsilon")) {
+                            finished = 1;
+                        }
+                        temp.add(new LR1Item(rule.getLeftSide(),rhs,finished,lookahead));
                     }
                 }
             }

--- a/src/util/Grammar.java
+++ b/src/util/Grammar.java
@@ -31,7 +31,9 @@ public class Grammar {
             for (String rule : rulesRightSide) {
                 String[] rightSide = rule.trim().split("\\s+");
                 for (String terminal : rightSide) {
-                    terminals.add(terminal);
+                    if (!terminal.equals("epsilon")) {
+                        terminals.add(terminal);
+                    }
                 }
 
                 if (line == 0) {
@@ -123,18 +125,19 @@ public class Grammar {
                 for (Rule rule : rules) {
                     for (int i = 0; i < rule.getRightSide().length; i++) {
                         if (rule.getRightSide()[i].equals(variable)) {
+                            HashSet<String> first;
                             if (i == rule.getRightSide().length - 1) {
-                                fallowSets.get(variable).addAll(fallowSets.get(rule.leftSide));
+                                first = fallowSets.get(rule.leftSide);
                             } else {
-                                HashSet<String> first = computeFirst(rule.getRightSide(), i + 1);
+                                first = computeFirst(rule.getRightSide(), i + 1);
                                 if (first.contains("epsilon")) {
                                     first.remove("epsilon");
                                     first.addAll(fallowSets.get(rule.leftSide));
                                 }
-                                if (!fallowSets.get(variable).containsAll(first)) {
-                                    isChange = true;
-                                    fallowSets.get(variable).addAll(first);
-                                }
+                            }
+                            if (!fallowSets.get(variable).containsAll(first)) {
+                                isChange = true;
+                                fallowSets.get(variable).addAll(first);
                             }
                         }
                     }
@@ -151,7 +154,7 @@ public class Grammar {
         if (index == string.length) {
             return first;
         }
-        if (terminals.contains(string[index])) {
+        if (terminals.contains(string[index]) || string[index].equals("epsilon")) {
             first.add(string[index]);
             return first;
         }
@@ -164,8 +167,8 @@ public class Grammar {
 
         if (first.contains("epsilon")) {
             if (index != string.length - 1) {
-                first.addAll(computeFirst(string, index + 1));
                 first.remove("epsilon");
+                first.addAll(computeFirst(string, index + 1));
             }
         }
         return first;


### PR DESCRIPTION
In the calculation of follow sets, the code may exit prematurely because it
may not recognize that it has made a change and should continue looping.

Epsilon shouldn't be added to the terminals because it is not a
terminal [1][2][3] and it also leads to epsilon being in the action table,
where it does not belong. Note that if it is no longer in the "terminals"
HashSet, there is a change needed in computeFirst to check for epsilon
explicitly.

There is another subtle problem at the bottom of computeFirst. The code
removes epsilon from the first set of a nullable intermediate non-terminal
and calls computeFirst recursively on the next nonterminal. Those are the
right things to do, but it does them in the wrong order. The recursive call
may legitimately return epsilon (if it is a last nonterminal with an
epsilon rule - see example above), but the code then removes it regardless.

In the closure of LR1State, there is a problem with computing the
next item for epsilon rules. When an epsilon item is created, it should be
"finished" immediately by placing the dot past the epsilon. This position
is where it should be so that REDUCE rules are created properly in
createActionTable(). Note that this is essentially what is suggested in [3]
except that they actually remove "epsilon" from the rule so that the
rule is more obviously completed.

Finally, there is a typo that results in an incorrect LR0 action table.

[1] https://cs.stackexchange.com/questions/85834/is-the-empty-string-a-terminal-symbol
[2] https://stackoverflow.com/questions/6501399/slr1-parser-and-epsilon-involved
[3] https://www.cs.uaf.edu/~cs331/notes/FirstFollow.pdf